### PR TITLE
Reihenfolge der Autoren ändern, Untertitel dazu

### DIFF
--- a/langsci/seriesinfo/tmnlp-info.tex
+++ b/langsci/seriesinfo/tmnlp-info.tex
@@ -3,9 +3,9 @@
 
 \bigskip
 
-Chief Editor: Reinhard Rapp (Johannes Gutenberg-Universität Mainz) \\
+Chief Editor: Oliver \v{C}ulo (Johannes Gutenberg-Universität Mainz) \\
 Consulting Editors: Silvia Hansen-Schirra (Johannes Gutenberg-Universität Mainz)
-Oliver Čulo (Johannes Gutenberg-Universität Mainz)
+Reinhard Rapp (Johannes Gutenberg-Universität Mainz)
 
 \bigskip
 
@@ -13,9 +13,9 @@ In this series:
 
 \begin{enumerate}
 \item Fantinuoli, Claudio \& Federico Zanettin (eds.). New directions in corpus-based translation studies.
-\item Neumann, Stella, Oliver Čulo \& Silvia Hansen-Schirra (eds.). Parallel corpora: Annotation, exploitation, evaluation.
-\item Čulo, Oliver  \& Silvia Hansen-Schirra (eds.). Crossroads between contrastive linguistics, translation studies and machine translation.
-\item Rehm, Georg, Felix Sasaki, Daniel Stein \& Andreas Witt (eds.). Language technologies for a multilingual Europe. 
+\item Neumann, Stella, Oliver Čulo \& Silvia Hansen-Schirra (eds.). Annotation, exploitation and evaluation of parallel corpora. Translation: Computation, Corpora, Cognition Part 1.
+\item Čulo, Oliver  \& Silvia Hansen-Schirra (eds.). Crossroads between contrastive linguistics, translation studies and machine translation. Translation: Computation, Corpora, Cognition Part 2.
+\item Rehm, Georg, Felix Sasaki, Daniel Stein \& Andreas Witt (eds.). Language technologies for a multilingual Europe. Translation: Computation, Corpora, Cognition Part 3.
 \item Hansen-Schirra, Silvia \& Sambor Grucza (eds.). Eyetracking and applied linguistics.
 \end{enumerate}
 


### PR DESCRIPTION
Ich habe mal die Reihenfolge der Autoren geändert, wobei der Editor Schwierigkeiten mit dem Hatschek in meinem Namen gab. Ich hab dann die alte LaTeX-Notation hergenommen. Außerdem habe ich noch die Untertitel hinzugefügt, wie ich mich so daran erinnerte, und habe einen Doppelpunkt im Titel des ersten Bandes gelöscht.